### PR TITLE
Fix typo in example c program

### DIFF
--- a/content/post/adding-instruction-riscv/index.md
+++ b/content/post/adding-instruction-riscv/index.md
@@ -85,7 +85,7 @@ Now compile the riscv-gnu-toolchain again and you are done.
 Lets write a program and see if the RISCV assembler can use the mod instruction:
 
 ```C
-#include <stdio,h>
+#include <stdio.h>
 
 int main(){
   int a,b,c;


### PR DESCRIPTION
This replaces a comma by a period to make the  `#include` valid.